### PR TITLE
Preserve votes when term does not change

### DIFF
--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -2282,8 +2282,11 @@ namespace aft
     {
       RAFT_DEBUG_FMT("Becoming aware of new term {}", term);
 
+      if (state->current_view != term)
+      {
+        voted_for.reset();
+      }
       state->current_view = term;
-      voted_for.reset();
       reset_votes_for_me();
       become_follower();
       is_new_follower = true;


### PR DESCRIPTION
## Summary

- keep `become_aware_of_new_term` as the single candidate step-down path
- only clear `voted_for` when the observed term is actually new
- preserve `voted_for` on same-term step-down while keeping higher-term handling unchanged

## Tradeoff

This is the clean one-vote-per-term fix. Same term is not a new term, so a same-term AppendEntries can still make a node step down, reset votes-for-me, and become a new follower, but it does not erase a regular vote already cast in that term. This matches the original `ccfraft.tla` behavior.

## Validation

- `raft_driver` blocks the #8094 three-node double-leader scenario at the second election
- corrected three-node recovery scenario passed
- all existing Raft scenarios passed
- corrected trace validation passed
- `scripts/ci-checks.sh` passed