### PR TITLE
Preserve pre-vote candidate votes on same-term step-down

### DIFF
--- a/src/consensus/aft/raft.h
+++ b/src/consensus/aft/raft.h
@@ -1141,7 +1141,17 @@ namespace aft
         (state->leadership_state == ccf::kv::LeadershipState::Candidate ||
          state->leadership_state == ccf::kv::LeadershipState::PreVoteCandidate))
       {
-        become_aware_of_new_term(r.term);
+        if (
+          state->leadership_state == ccf::kv::LeadershipState::PreVoteCandidate)
+        {
+          reset_votes_for_me();
+          become_follower();
+          is_new_follower = true;
+        }
+        else
+        {
+          become_aware_of_new_term(r.term);
+        }
       }
       else if (state->current_view < r.term)
       {

--- a/tla/consensus/ccfraft.tla
+++ b/tla/consensus/ccfraft.tla
@@ -1061,8 +1061,10 @@ ReturnToFollowerState(i, m) ==
     /\ leadershipState[i] \in {PreVoteCandidate, Candidate}
     /\ leadershipState' = [leadershipState EXCEPT ![i] = Follower]
     /\ isNewFollower' = [isNewFollower EXCEPT ![i] = TRUE]
+    /\ votedFor' = [votedFor EXCEPT
+        ![i] = IF leadershipState[i] = Candidate THEN Nil ELSE @]
     \* Note that the set of messages is unchanged as m is discarded
-    /\ UNCHANGED <<preVoteStatus, reconfigurationVars, currentTerm, votedFor, logVars, 
+    /\ UNCHANGED <<preVoteStatus, reconfigurationVars, currentTerm, logVars,
         messages, membershipState, candidateVars, leaderVars>>
 
 \* Follower i receives a AppendEntries from leader j for log entries it already has


### PR DESCRIPTION
## Summary

- preserve `voted_for` only when a PreVoteCandidate steps down on same-term AppendEntries
- retain the existing regular Candidate same-term reset behavior
- model the distinction in `ccfraft.tla`

## Tradeoff

This is the narrowest fix for the demonstrated bug. It keeps #8091's regular-candidate behavior while closing the pre-vote path that creates overlapping quorums.

## Validation

- `raft_driver` blocks the #8094 three-node double-leader scenario at the second election
- corrected three-node recovery scenario passed
- all existing Raft scenarios passed
- corrected trace validation passed
- focused bounded TLA model check passed: `1C2N`, `term-count 1`, `request-count 0`
- `scripts/ci-checks.sh` passed